### PR TITLE
Add proprietary license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2024 The Repository Owner. All rights reserved.
+
+This repository is licensed for the exclusive personal use of the repository owner.
+No other individual or organization is permitted to use, copy, distribute,
+modify, or fork this repository or any portion of its contents without
+explicit written permission from the repository owner.
+

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ class Queue32 extends Module { … }
 
 sbt test → target/SpecIndex.json
 
+
+## License
+
+This project is proprietary and intended for the exclusive personal use of the repository owner. Forking, distribution, and external contributions are prohibited without explicit written permission.


### PR DESCRIPTION
## Summary
- add `LICENSE` describing proprietary restrictions
- document license terms in README

## Testing
- `./publish.sh`
- `jq 'length > 0' design/target/SpecIndex.json`
- `jq 'length > 0' design/target/TagIndex.json`
- `jq -e '.[0] | has("id") and has("category")' design/target/SpecIndex.json`
- `jq -e '.[0] | has("scalaDeclarationPath") and has("srcFile")' design/target/TagIndex.json`
- `diff -u design/golden/SpecIndex.golden.json design/target/SpecIndex.sorted.json`
- `diff -u design/golden/TagIndex.golden.json design/target/TagIndex.sorted.json`

------
https://chatgpt.com/codex/tasks/task_e_6877072f45cc8325a2e9eb1bbd2bbc08