### PR TITLE
Add BUNDLE spec category

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ It is organized as several sbt subprojects:
 - **spec-plugin** – sbt plugin for exporting JSON indexes
 - **design** – example project using the framework
 
+The DSL offers categories such as `CONTRACT`, `FUNCTION`, and `INTERFACE`.  The
+`BUNDLE` category can be used to document reusable data structures referenced by
+interfaces.
+
 To build everything offline run:
 
 ```bash

--- a/design/src/main/scala/your_project/specs/BundleSpecs.scala
+++ b/design/src/main/scala/your_project/specs/BundleSpecs.scala
@@ -1,0 +1,21 @@
+package your_project.specs
+
+import framework.macros.SpecEmit.spec
+import framework.spec.Spec._
+
+object BundleSpecs {
+  val fetchReqBundle = spec {
+    BUNDLE("BND_FETCH_REQ_BUNDLE")
+      .desc("Simple fetch request bundle")
+      .entry("pc", "Program counter [type: UInt, width: 32]")
+      .entry("valid", "Request valid [type: Bool]")
+      .build()
+  }
+
+  val busInterface = spec {
+    INTERFACE("INTF_FETCH_BUS")
+      .desc("Bus interface using fetch request bundle")
+      .entry("request", "Outgoing request").has("BND_FETCH_REQ_BUNDLE")
+      .build()
+  }
+}

--- a/docs/user_guide_213.md
+++ b/docs/user_guide_213.md
@@ -24,6 +24,25 @@ object MySpecs {
 
 Call `.build()` at the end so the spec is registered in `SpecRegistry` and written to a meta file.
 
+### BUNDLE Specs
+
+Use the `BUNDLE` category to describe reusable data structures referenced by interfaces.
+
+```scala
+val FetchReq = spec {
+  BUNDLE("BND_FETCH_REQ").desc("Fetch request bundle")
+    .entry("pc", "Program counter [type: UInt, width: 32]")
+    .entry("valid", "Request valid flag [type: Bool]")
+    .build()
+}
+
+val BusIntf = spec {
+  INTERFACE("INTF_BUS").desc("Example interface")
+    .entry("req", "Request channel").has(FetchReq)
+    .build()
+}
+```
+
 ## 2. Tagging Code
 
 Use the `@LocalSpec("SPEC_ID")` annotation to mark modules, vals or defs that implement or verify a spec.

--- a/spec-core/src/main/scala/framework/spec/HardwareSpecification.scala
+++ b/spec-core/src/main/scala/framework/spec/HardwareSpecification.scala
@@ -44,6 +44,7 @@ object HardwareSpecification {
     case object INTERFACE          extends SpecCategory // Interface spec
     case object PARAMETER          extends SpecCategory // Parameter spec
     case object CAPABILITY         extends SpecCategory // Capability spec
+    case object BUNDLE            extends SpecCategory // Bundle spec
     case class RAW(prefix: String) extends SpecCategory // Custom/raw category
 
   // upickle ReadWriter for SpecCategory (string-based encoding)
@@ -57,6 +58,7 @@ object HardwareSpecification {
         case SpecCategory.INTERFACE   => "INTERFACE"
         case SpecCategory.PARAMETER   => "PARAMETER"
         case SpecCategory.CAPABILITY  => "CAPABILITY"
+        case SpecCategory.BUNDLE      => "BUNDLE"
         case SpecCategory.RAW(prefix) => s"RAW:$prefix"
       },
       {
@@ -67,6 +69,7 @@ object HardwareSpecification {
         case "INTERFACE"               => SpecCategory.INTERFACE
         case "PARAMETER"               => SpecCategory.PARAMETER
         case "CAPABILITY"              => SpecCategory.CAPABILITY
+        case "BUNDLE"                  => SpecCategory.BUNDLE
         case s if s.startsWith("RAW:") => SpecCategory.RAW(s.drop(4))
         case other                     =>
           throw new IllegalArgumentException(s"Unknown SpecCategory: $other")

--- a/spec-core/src/main/scala/framework/spec/Spec.scala
+++ b/spec-core/src/main/scala/framework/spec/Spec.scala
@@ -11,6 +11,7 @@ object Spec {
   def INTERFACE(id: String): Stage1 = new Stage1(SpecCategory.INTERFACE, id)
   def PARAMETER(id: String): Stage1 = new Stage1(SpecCategory.PARAMETER, id)
   def CAPABILITY(id: String): Stage1= new Stage1(SpecCategory.CAPABILITY, id)
+  def BUNDLE(id: String): Stage1    = new Stage1(SpecCategory.BUNDLE, id)
   def RAW(id: String, prefix: String): Stage1 = new Stage1(SpecCategory.RAW(prefix), id)
 
   // stage1: require description


### PR DESCRIPTION
## Summary
- support new `BUNDLE` category in Spec DSL and data model
- document BUNDLE usage in README and user guide
- add example BundleSpecs

## Testing
- `./publish.sh`


------
https://chatgpt.com/codex/tasks/task_e_687f65f720848325958709a3ba025343