### PR TITLE
Add English usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ See `docs/architecture.md` for an overview, `docs/PLUGIN_USAGE.md` for sbt setup
 details on hacking the framework. Coding style conventions are documented in
 `docs/SCALADOC_STYLE_GUIDE.md`.
 
+For English documentation, refer to
+[`docs/plugin_enable_en.md`](docs/plugin_enable_en.md),
+[`docs/builder_usage_en.md`](docs/builder_usage_en.md) and
+[`docs/localspec_usage_en.md`](docs/localspec_usage_en.md).
+
+For Korean documentation, refer to
+[`docs/plugin_enable_ko.md`](docs/plugin_enable_ko.md),
+[`docs/builder_usage_ko.md`](docs/builder_usage_ko.md) and
+[`docs/localspec_usage_ko.md`](docs/localspec_usage_ko.md).
+
 ## License
 
 This project is proprietary and intended for the exclusive personal use of the repository owner.

--- a/docs/builder_usage_en.md
+++ b/docs/builder_usage_en.md
@@ -1,0 +1,67 @@
+# Spec Builder Usage (English)
+
+This guide explains how to write hardware specifications with the `framework.spec.Spec` DSL. It matches the current `Spec.scala` implementation.
+
+## 1. Basic structure
+
+Choose a category, call `desc` for the description, chain any options, and finish with `build()`.
+
+```scala
+import framework.macros.SpecEmit.spec
+import framework.spec.Spec._
+
+val mySpec = spec {
+  CONTRACT("EXAMPLE_ID").desc("Example spec")
+    .status("DRAFT")
+    .entry("Author", "HW Team")
+    .build()
+}
+```
+
+Within a `spec { ... }` block, calling `build()` generates a meta file at compile time and registers the spec at runtime.
+
+## 2. Stage2 methods
+
+After calling `desc` you can use these methods:
+
+| Method | Description |
+|-------|-------------|
+| `status(String)` | Sets the status value of the spec. |
+| `is(spec* )` | Reference another spec ID or object. |
+| `has(spec* )` | Declare child spec IDs or objects. |
+| `uses(spec* )` | Express dependencies between CONTRACT specs. |
+| `entry(key, value)` | Add a key-value item. If `value` is omitted it becomes a hierarchical list item. |
+| `table(tableType, content)` | Add a table string such as Markdown or CSV. |
+| `markdownTable(headers, rows)` | Build a Markdown table from lists. |
+| `draw(drawType, content)` | Insert a diagram such as mermaid, svg or ascii. |
+| `code(language, content)` | Insert a code block. Default language is `text`. |
+| `note(text)` | Add a note or additional comment. |
+| `build(scalaDeclarationPath)` | Finalize the spec and register it. |
+
+For hierarchical lists include indentation in the first argument to `entry`.
+
+```scala
+val spec = FUNCTION("PIPELINE").desc("Pipeline behavior")
+  .entry("- stages")
+  .entry("  - IF")
+  .entry("  - ID")
+  .entry("  - EX")
+  .build()
+```
+
+## 3. Example
+
+```scala
+val example = spec {
+  INTERFACE("BUS").desc("Bus interface")
+    .is("DMA_CONTROLLER")
+    .entry("addr", "Address input")
+    .table("csv", "Signal,Width\naddr,32")
+    .draw("mermaid", "graph TD; A-->B")
+    .code("verilog", "module bus(...);")
+    .note("Additional description")
+    .build()
+}
+```
+
+The spec is registered in `SpecRegistry` and saved to JSON when you run `exportSpecIndex`.

--- a/docs/builder_usage_ko.md
+++ b/docs/builder_usage_ko.md
@@ -1,0 +1,67 @@
+# Spec Builder 사용법 (한국어)
+
+이 문서는 `framework.spec.Spec` DSL을 이용해 하드웨어 스펙을 작성하는 방법을 설명합니다. 현재 코드베이스의 `Spec.scala` 구현에 맞춰 설명됩니다.
+
+## 1. 기본 구조
+
+스펙은 카테고리를 선택한 뒤 `desc` 로 설명을 적고, 필요한 옵션을 이어서 호출한 후 `build()` 로 마무리합니다.
+
+```scala
+import framework.macros.SpecEmit.spec
+import framework.spec.Spec._
+
+val mySpec = spec {
+  CONTRACT("EXAMPLE_ID").desc("예시 스펙")
+    .status("DRAFT")
+    .entry("Author", "HW Team")
+    .build()
+}
+```
+
+`spec { ... }` 블록 안에서 `build()` 가 호출되면 컴파일 시 메타 파일이 생성되고 런타임 레지스트리에 등록됩니다.
+
+## 2. Stage2 메서드
+
+`desc` 를 호출한 이후에는 다음과 같은 메서드들을 사용할 수 있습니다.
+
+| 메서드 | 설명 |
+|-------|------|
+| `status(String)` | 스펙의 상태 값을 설정합니다. |
+| `is(spec* )` | 다른 스펙 ID 혹은 스펙 객체를 참조합니다. |
+| `has(spec* )` | 하위 스펙 ID 혹은 스펙 객체를 나타냅니다. |
+| `uses(spec* )` | CONTRACT 카테고리 간의 의존 관계를 표현합니다. |
+| `entry(key, value)` | 키-값 형태의 항목을 추가합니다. `value` 를 생략하면 계층형 리스트 항목으로 취급합니다. |
+| `table(tableType, content)` | Markdown, CSV 등 문자열로 테이블을 추가합니다. |
+| `markdownTable(headers, rows)` | 헤더와 행 리스트를 이용해 Markdown 테이블을 만듭니다. |
+| `draw(drawType, content)` | mermaid, svg, ascii 등의 그림을 삽입합니다. |
+| `code(language, content)` | 코드 블록을 삽입합니다. 기본 언어는 `text` 입니다. |
+| `note(text)` | 메모 혹은 추가 설명을 남깁니다. |
+| `build(scalaDeclarationPath)` | 스펙을 완성하여 레지스트리에 등록합니다. |
+
+계층형 리스트를 표현할 때는 `entry` 의 첫 번째 인자에 들여쓰기를 포함한 문자열을 사용합니다.
+
+```scala
+val spec = FUNCTION("PIPELINE").desc("파이프라인 동작")
+  .entry("- 단계")
+  .entry("  - IF")
+  .entry("  - ID")
+  .entry("  - EX")
+  .build()
+```
+
+## 3. 예시
+
+```scala
+val example = spec {
+  INTERFACE("BUS").desc("버스 인터페이스")
+    .is("DMA_CONTROLLER")
+    .entry("addr", "주소 입력")
+    .table("csv", "Signal,Width\naddr,32")
+    .draw("mermaid", "graph TD; A-->B")
+    .code("verilog", "module bus(...);")
+    .note("추가 설명")
+    .build()
+}
+```
+
+이렇게 작성된 스펙은 `SpecRegistry` 에 등록되고 `exportSpecIndex` 실행 시 JSON 파일로 저장됩니다.

--- a/docs/localspec_usage_en.md
+++ b/docs/localspec_usage_en.md
@@ -1,0 +1,59 @@
+# LocalSpec Macro Usage (English)
+
+The `@LocalSpec` macro marks modules, values or methods that implement a specification. During compilation tag information is written to meta files and later included in the JSON index when `exportSpecIndex` is run.
+
+## 1. Preparation
+
+- Enable `SpecPlugin` and add the `-Ymacro-annotations` option. See [plugin_enable_en.md](plugin_enable_en.md) for details.
+- Spec definitions are usually written inside `spec { ... }` blocks and stored as `val`s.
+
+```scala
+import framework.macros.SpecEmit.spec
+import framework.spec.Spec._
+
+object MySpecs {
+  val QueueSpec = spec {
+    CONTRACT("QUEUE_CONTRACT").desc("Queue module spec")
+      .build()
+  }
+}
+```
+
+## 2. Tagging modules
+
+Pass a spec object or ID string to the annotation for modules, values or methods.
+
+```scala
+import chisel3._
+import framework.macros.LocalSpec
+import MySpecs._
+
+@LocalSpec(QueueSpec)
+class QueueModule extends Module {
+  val io = IO(new Bundle {
+    val enq = Flipped(Decoupled(UInt(32.W)))
+    val deq = Decoupled(UInt(32.W))
+  })
+  // implementation
+}
+```
+
+If you cannot annotate an expression directly, declare a dummy `val`:
+
+```scala
+@LocalSpec(QueueSpec)
+val tagForWhen = ()
+when(io.enq.valid) {
+  // ...
+}
+```
+
+## 3. Running and results
+
+When the annotated code runs, `SpecRegistry` records the tag information. Then execute the following in sbt to generate the JSON files:
+
+```bash
+sbt exportSpecIndex
+```
+
+`SpecIndex.json` and `TagIndex.json` will be generated under `design/target/` (or your configured path) with the source location of each tag.

--- a/docs/localspec_usage_ko.md
+++ b/docs/localspec_usage_ko.md
@@ -1,0 +1,59 @@
+# LocalSpec 매크로 사용법 (한국어)
+
+`@LocalSpec` 매크로는 하드웨어 모듈이나 값, 메서드가 어떤 스펙을 구현하는지 표시하기 위해 사용됩니다. 컴파일 단계에서 태그 정보를 메타 파일로 기록하며, 이후 `exportSpecIndex` 실행 시 JSON 인덱스에 포함됩니다.
+
+## 1. 준비
+
+- `SpecPlugin`을 활성화하고 `-Ymacro-annotations` 옵션을 설정해야 합니다. 자세한 설정 방법은 [plugin_enable_ko.md](plugin_enable_ko.md)를 참고하십시오.
+- 스펙 정의는 보통 `spec { ... }` 블록에서 작성하고 `val` 로 저장합니다.
+
+```scala
+import framework.macros.SpecEmit.spec
+import framework.spec.Spec._
+
+object MySpecs {
+  val QueueSpec = spec {
+    CONTRACT("QUEUE_CONTRACT").desc("큐 모듈 규격")
+      .build()
+  }
+}
+```
+
+## 2. 모듈에 태그 달기
+
+스펙 객체나 스펙 ID 문자열을 인자로 전달하여 모듈, 값, 메서드 등에 어노테이션을 붙입니다.
+
+```scala
+import chisel3._
+import framework.macros.LocalSpec
+import MySpecs._
+
+@LocalSpec(QueueSpec)
+class QueueModule extends Module {
+  val io = IO(new Bundle {
+    val enq = Flipped(Decoupled(UInt(32.W)))
+    val deq = Decoupled(UInt(32.W))
+  })
+  // 구현부
+}
+```
+
+어노테이션을 직접 붙일 수 없는 표현식에는 더미 `val`을 선언하여 태그를 남길 수 있습니다.
+
+```scala
+@LocalSpec(QueueSpec)
+val tagForWhen = ()
+when(io.enq.valid) {
+  // ...
+}
+```
+
+## 3. 실행 및 결과
+
+어노테이션이 달린 코드가 실행되면 `SpecRegistry` 에 태그 정보가 기록됩니다. 이후 sbt에서 다음 명령을 실행하여 JSON 파일을 생성합니다.
+
+```bash
+sbt exportSpecIndex
+```
+
+`design/target/`(또는 설정한 경로)에 `SpecIndex.json`과 `TagIndex.json`이 생성되며, 각 태그의 소스 위치가 포함됩니다.

--- a/docs/plugin_enable_en.md
+++ b/docs/plugin_enable_en.md
@@ -1,0 +1,53 @@
+# SpecPlugin Usage (English)
+
+This document explains how to apply the SpecPlugin to your project based on the current codebase.
+
+## 1. Adding the plugin
+
+Add the following line to `project/plugins.sbt` to load the sbt plugin:
+
+```scala
+addSbtPlugin("your.company" % "spec-plugin" % "0.1.0-SNAPSHOT")
+```
+
+## 2. Library dependencies
+
+Inside your `build.sbt` project settings add the following libraries:
+
+```scala
+libraryDependencies ++= Seq(
+  "your.company" %% "spec-core"   % "0.1.0-SNAPSHOT",
+  "your.company" %% "spec-macros" % "0.1.0-SNAPSHOT",
+  "edu.berkeley.cs" %% "chisel3"  % "3.6.0"            // if needed
+)
+```
+
+## 3. Enabling the plugin and options
+
+Enable `SpecPlugin` and configure macro options in your project definition:
+
+```scala
+lazy val design = (project in file("."))
+  .enablePlugins(SpecPlugin)
+  .settings(
+    Compile / scalacOptions += "-Ymacro-annotations",
+    initialize := {
+      val _  = initialize.value
+      val dir = (Compile / resourceManaged).value / "spec-meta"
+      System.setProperty("spec.meta.dir", dir.getAbsolutePath)
+    },
+    publish / skip := true
+  )
+```
+
+This sets the `spec.meta.dir` system property so the macros emit metadata to that location.
+
+## 4. Generating the index
+
+After compilation run the following task:
+
+```bash
+sbt exportSpecIndex
+```
+
+`SpecIndex.json` and `TagIndex.json` will appear under the directory specified by `spec.meta.dir` (default `design/target/`).

--- a/docs/plugin_enable_ko.md
+++ b/docs/plugin_enable_ko.md
@@ -1,0 +1,53 @@
+# SpecPlugin 사용법 (한국어)
+
+이 문서는 현재 코드베이스에 맞춰 SpecPlugin을 프로젝트에 적용하는 방법을 설명합니다.
+
+## 1. 플러그인 추가
+
+`project/plugins.sbt` 파일에 다음 라인을 추가해 sbt 플러그인을 불러옵니다.
+
+```scala
+addSbtPlugin("your.company" % "spec-plugin" % "0.1.0-SNAPSHOT")
+```
+
+## 2. 라이브러리 의존성 설정
+
+`build.sbt`의 프로젝트 설정 안에서 다음 라이브러리들을 추가합니다.
+
+```scala
+libraryDependencies ++= Seq(
+  "your.company" %% "spec-core"   % "0.1.0-SNAPSHOT",
+  "your.company" %% "spec-macros" % "0.1.0-SNAPSHOT",
+  "edu.berkeley.cs" %% "chisel3"  % "3.6.0"            // 필요한 경우
+)
+```
+
+## 3. 플러그인 활성화 및 옵션
+
+프로젝트 정의에 `SpecPlugin`을 활성화하고 매크로 사용을 위해 컴파일 옵션을 지정합니다.
+
+```scala
+lazy val design = (project in file("."))
+  .enablePlugins(SpecPlugin)
+  .settings(
+    Compile / scalacOptions += "-Ymacro-annotations",
+    initialize := {
+      val _  = initialize.value
+      val dir = (Compile / resourceManaged).value / "spec-meta"
+      System.setProperty("spec.meta.dir", dir.getAbsolutePath)
+    },
+    publish / skip := true
+  )
+```
+
+위 설정은 `spec.meta.dir` 시스템 프로퍼티를 지정하여 매크로가 메타 데이터를 해당 위치에 출력하도록 합니다.
+
+## 4. 인덱스 생성
+
+컴파일 후 `exportSpecIndex` 태스크를 실행하면 `SpecIndex.json`과 `TagIndex.json`이 생성됩니다.
+
+```bash
+sbt exportSpecIndex
+```
+
+출력 경로는 위에서 설정한 `spec.meta.dir`에 따라 결정되며 기본값은 `design/target/` 입니다.


### PR DESCRIPTION
## Summary
- link the new English docs in the README
- document how to enable SpecPlugin in English
- add English guide to the builder DSL
- add English tutorial for `@LocalSpec`

## Testing
- `./publish.sh`
- `jq -S '.' design/target/SpecIndex.json > design/target/SpecIndex.sorted.json`
- `jq -S '.' design/target/TagIndex.json > design/target/TagIndex.sorted.json`


------
https://chatgpt.com/codex/tasks/task_e_68801c0637a48325b1f0628b55ae48cb