### PR TITLE
Adopt PascalCase spec IDs and refresh docs

### DIFF
--- a/design/src/main/scala/your_project/design/ObjectRefExample.scala
+++ b/design/src/main/scala/your_project/design/ObjectRefExample.scala
@@ -8,7 +8,7 @@ import your_project.specs.MyExampleSpecs._
   */
 object ObjectRefExample {
   val exampleSpec =
-    CONTRACT("OBJ_REF_EXAMPLE").desc("Spec with object references")
+    CONTRACT("ObjRefExample").desc("Spec with object references")
       .is(TestInterfaceSpec, DummyStatusSpec)
       .has(DummyObjSpec)
       .uses(TestModuleSpec)

--- a/design/src/main/scala/your_project/specs/MyExampleSpecs.scala
+++ b/design/src/main/scala/your_project/specs/MyExampleSpecs.scala
@@ -12,35 +12,35 @@ object MyExampleSpecs {
   // -----------------------------------------------------------------------------
   // Test module spec for CI coverage
   val TestModuleSpec = spec {
-    CONTRACT("TEST_MODULE").desc("Test module spec for CI coverage")
+    CONTRACT("TestModule").desc("Test module spec for CI coverage")
       .entry("ModuleKey", "ModuleValue")
       .build()
   }
 
   // Test interface spec for CI coverage
   val TestInterfaceSpec = spec {
-    INTERFACE("TEST_INTERFACE").desc("Test interface spec for CI coverage")
+    INTERFACE("TestInterface").desc("Test interface spec for CI coverage")
       .entry("InterfaceKey", "InterfaceValue")
       .build()
   }
 
   // 3. Test assign spec for CI coverage
   val TestAssignSpec = spec {
-    FUNCTION("TEST_ASSIGN").desc("Test assignment spec for CI coverage")
+    FUNCTION("TestAssign").desc("Test assignment spec for CI coverage")
       .entry("AssignKey", "AssignValue")
       .build()
   }
 
   // Minimal FUNCTION spec (literal)
   val DummyLiteralSpec = spec {
-    FUNCTION("DUMMY_LITERAL").desc("Dummy spec for literal test")
+    FUNCTION("DummyLiteral").desc("Dummy spec for literal test")
       .entry("Key", "Value")
       .build()
   }
 
   // PROPERTY spec with noCapability
   val DummyObjSpec = spec {
-    PROPERTY("DUMMY_OBJ").desc("Dummy spec for object test")
+    PROPERTY("DummyObj").desc("Dummy spec for object test")
       .status("DRAFT")
       .entry("ObjKey", "ObjValue")
       .build()
@@ -48,61 +48,61 @@ object MyExampleSpecs {
 
   // CONTRACT spec with parents/related
   val DummyCaseSpec = spec {
-    CONTRACT("DUMMY_CASE").desc("Dummy spec for case class test")
+    CONTRACT("DummyCase").desc("Dummy spec for case class test")
       .entry("CaseKey", "CaseValue")
       .build()
   }
 
   // PARAMETER spec for expression/statement annotation
   val DummyWhenSpec = spec {
-    FUNCTION("DUMMY_WHEN").desc("Dummy spec for when statement test")
+    FUNCTION("DummyWhen").desc("Dummy spec for when statement test")
       .entry("StatementKey", "StatementValue")
       .build()
   }
 
   val DummyAssignSpec = spec {
-    FUNCTION("DUMMY_ASSIGNN").desc("Dummy spec for assignment statement test")
+    FUNCTION("DummyAssign").desc("Dummy spec for assignment statement test")
       .entry("StatementKey", "StatementValue")
       .build()
   }
 
   val DummySwitchSpec = spec {
-    FUNCTION("DUMMY_Switch").desc("Dummy spec for switch statement test")
+    FUNCTION("DummySwitch").desc("Dummy spec for switch statement test")
       .entry("StatementKey", "StatementValue")
       .build()
   }
 
   // INTERFACE spec with metadata and requiredCaps
   val DummyMetaSpec = spec {
-    INTERFACE("DUMMY_META").desc("Dummy spec with metadata and requiredCaps")
+    INTERFACE("DummyMeta").desc("Dummy spec with metadata and requiredCaps")
       .entry("MetaKey", "MetaValue")
       .build()
   }
 
   // RAW spec with custom prefix
   val DummyRawSpec = spec {
-    RAW("DUMMY_RAW", "RAW_PREFIX").desc("Dummy raw spec")
+    RAW("DummyRaw", "RAW_PREFIX").desc("Dummy raw spec")
       .entry("RawKey", "RawValue")
       .build()
   }
 
   // FUNCTION spec with impl/verified
   val DummyImplSpec = spec {
-    FUNCTION("DUMMY_IMPL").desc("Dummy spec with impl/verified")
+    FUNCTION("DummyImpl").desc("Dummy spec with impl/verified")
       .entry("ImplKey", "ImplValue")
       .build()
   }
 
   // PROPERTY spec with multiple entries
   val DummyMultiEntrySpec = spec {
-    PROPERTY("DUMMY_MULTI").desc("Dummy spec with multiple entries")
+    PROPERTY("DummyMulti").desc("Dummy spec with multiple entries")
       .entry("A", "1").entry("B", "2").entry("C", "3")
       .build()
   }
 
   // FUNCTION spec with status and metadata
   val DummyStatusSpec = spec {
-    FUNCTION("DUMMY_STATUS").desc("Dummy spec with status and metadata")
+    FUNCTION("DummyStatus").desc("Dummy spec with status and metadata")
       .status("APPROVED")
       .entry("StatusKey", "StatusValue")
       .build()
@@ -110,17 +110,17 @@ object MyExampleSpecs {
 
   // COVERAGE spec with related and parents
   val DummyCoverageSpec = spec {
-    COVERAGE("DUMMY_COVERAGE").desc("Dummy coverage spec")
+    COVERAGE("DummyCoverage").desc("Dummy coverage spec")
       .entry("CovKey", "CovValue")
       .build()
   }
 
   // Comprehensive spec exercising all DSL builder methods
   val ComplexSpec = spec {
-    CONTRACT("COMPLEX").desc("Spec exercising all builder methods")
-      .is("TEST_INTERFACE", "DUMMY_STATUS")
-      .has("DUMMY_OBJ")
-      .uses("TEST_MODULE")
+    CONTRACT("Complex").desc("Spec exercising all builder methods")
+      .is("TestInterface", "DummyStatus")
+      .has("DummyObj")
+      .uses("TestModule")
       .status("DRAFT")
       .entry("Key1", "Val1").entry("Key2", "Val2")
       .entry("- Main Features")

--- a/docs/builder_usage_en.md
+++ b/docs/builder_usage_en.md
@@ -11,7 +11,7 @@ import framework.macros.SpecEmit.spec
 import framework.spec.Spec._
 
 val mySpec = spec {
-  CONTRACT("EXAMPLE_ID").desc("Example spec")
+  CONTRACT("ExampleSpec").desc("Example spec")
     .status("DRAFT")
     .entry("Author", "HW Team")
     .build()
@@ -36,11 +36,16 @@ The DSL provides several category constructors. Pick one that matches the type o
 | `BUNDLE` | `BUNDLE(id)` | Reusable data structure referenced by interfaces. |
 | `RAW` | `RAW(id, prefix)` | Custom category with the given prefix. |
 
+### Naming convention
+
+- **Use PascalCase identifiers.** `CONTRACT`, `FUNCTION`, and every other category should be given an identifier like `AddressGenerationUnit` or `AxiBus`. The canonical spec ID is the same PascalCase value across DSL, JSON, and referencing code.
+- **Match Scala classes when bound.** When a spec represents a Scala module annotated with `@LocalSpec`, give the `CONTRACT` the exact simple class name so reflection stays one-to-one.
+
 Example usage:
 
 ```scala
 val contCoreReq  = spec {
-  CONTRACT("CORE_REQ")
+  CONTRACT("CoreRequirement")
   .desc("Core requirement")
    ...
   .entry("Function", "RISCV ISA compliant configurable core")
@@ -49,7 +54,7 @@ val contCoreReq  = spec {
 }
 
 val funcAddFn  = spec {
-  FUNCTION("ADD_FN")
+  FUNCTION("AddFunction")
   .is(contAlu)
    ...
   .desc("Addition function")
@@ -57,8 +62,8 @@ val funcAddFn  = spec {
   .build() 
 }
 
-val bndAwChannel    = spec { 
-  BUNDLE("AW_CHANNEL")
+val bndAwChannel    = spec {
+  BUNDLE("AwChannel")
   .desc("Write Request")
   .has(paramAxiBus)
    ...
@@ -69,7 +74,7 @@ val bndAwChannel    = spec {
 }
 
 val intfAxiBus = spec {
-  INTERFACE("AXI_BUS")
+  INTERFACE("AxiBus")
     .desc("Bus interface")
      ...
     .has(bndAwChannel)
@@ -78,7 +83,7 @@ val intfAxiBus = spec {
 }
 
 val rawSdcAsyncClock = spec {
-  RAW("RAW_SDC_ASYNC_CLOCK", "SDC")
+  RAW("RawSdcAsyncClock", "SDC")
     .desc("Async-clock groups defined for this module/domain.")
     .markdownTable(
       List("Group-A", "Group-B", "Comment"),
@@ -118,7 +123,7 @@ After calling `desc` you can use these methods - all optional except for build()
 For hierarchical lists include indentation in the first argument to `entry`.
 
 ```scala
-val spec = FUNCTION("PIPELINE").desc("Pipeline behavior")
+val spec = FUNCTION("Pipeline").desc("Pipeline behavior")
   .entry("- stages")
   .entry("  - IF")
   .entry("  - ID")
@@ -130,8 +135,8 @@ val spec = FUNCTION("PIPELINE").desc("Pipeline behavior")
 
 ```scala
 val example = spec {
-  INTERFACE("BUS").desc("Bus interface")
-    .is("DMA_CONTROLLER")
+  INTERFACE("Bus").desc("Bus interface")
+    .is("DmaController")
     .entry("addr", "Address input")
     .table("csv", "Signal,Width\naddr,32")
     .draw("mermaid", "graph TD; A-->B")

--- a/docs/builder_usage_ko.md
+++ b/docs/builder_usage_ko.md
@@ -11,7 +11,7 @@ import framework.macros.SpecEmit.spec
 import framework.spec.Spec._
 
 val mySpec = spec {
-  CONTRACT("EXAMPLE_ID").desc("예시 스펙")
+  CONTRACT("ExampleSpec").desc("예시 스펙")
     .status("DRAFT")
     .entry("Author", "HW Team")
     .build()
@@ -36,12 +36,17 @@ val mySpec = spec {
 | `BUNDLE` | `BUNDLE(id)` | 인터페이스에서 참조하는 재사용 가능한 데이터 구조입니다. |
 | `RAW` | `RAW(id, prefix)` | 접두사를 가진 사용자 정의 카테고리입니다. |
 
+### 네이밍 규칙
+
+- **항상 PascalCase 식별자를 사용하세요.** `CONTRACT`, `FUNCTION` 등 모든 카테고리는 `AddressGenerationUnit`, `AxiBus`처럼 PascalCase 값을 ID로 사용합니다. 이 값이 DSL, JSON, 참조 코드에서 동일한 정규 ID가 됩니다.
+- **Scala 클래스와 1:1 로 맞추세요.** `@LocalSpec` 으로 연결된 모듈이라면 `CONTRACT` ID를 해당 Scala 클래스의 단순 이름과 완전히 동일하게 지정해야 리플렉션 결과와 일치합니다.
+
 예시:
 
 
 ```scala
 val contCoreReq  = spec {
-  CONTRACT("CORE_REQ")
+  CONTRACT("CoreRequirement")
   .desc("Core requirement")
    ...
   .entry("Function", "RISCV ISA compliant configurable core")
@@ -50,7 +55,7 @@ val contCoreReq  = spec {
 }
 
 val funcAddFn  = spec {
-  FUNCTION("ADD_FN")
+  FUNCTION("AddFunction")
   .is(contAlu)
    ...
   .desc("Addition function")
@@ -58,8 +63,8 @@ val funcAddFn  = spec {
   .build() 
 }
 
-val bndAwChannel    = spec { 
-  BUNDLE("AW_CHANNEL")
+val bndAwChannel    = spec {
+  BUNDLE("AwChannel")
   .desc("Write Request")
   .has(paramAxiBus)
    ...
@@ -70,7 +75,7 @@ val bndAwChannel    = spec {
 }
 
 val intfAxiBus = spec {
-  INTERFACE("AXI_BUS")
+  INTERFACE("AxiBus")
     .desc("Bus interface")
      ...
     .has(bndAwChannel)
@@ -79,7 +84,7 @@ val intfAxiBus = spec {
 }
 
 val rawAsyncClockSdc = spec {
-  RAW("RAW_ASYNC_CLOCK", "SDC")
+  RAW("RawAsyncClock", "SDC")
   .desc("async clock groups in this module/domain")
    ...
   .entry("coreClk", "periClk")
@@ -109,7 +114,7 @@ val rawAsyncClockSdc = spec {
 계층형 리스트를 표현할 때는 `entry` 의 첫 번째 인자에 들여쓰기를 포함한 문자열을 사용합니다.
 
 ```scala
-val spec = FUNCTION("PIPELINE").desc("파이프라인 동작")
+val spec = FUNCTION("Pipeline").desc("파이프라인 동작")
   .entry("- 단계")
   .entry("  - IF")
   .entry("  - ID")
@@ -121,8 +126,8 @@ val spec = FUNCTION("PIPELINE").desc("파이프라인 동작")
 
 ```scala
 val example = spec {
-  INTERFACE("BUS").desc("버스 인터페이스")
-    .is("DMA_CONTROLLER")
+  INTERFACE("Bus").desc("버스 인터페이스")
+    .is("DmaController")
     .entry("addr", "주소 입력")
     .table("csv", "Signal,Width\naddr,32")
     .draw("mermaid", "graph TD; A-->B")


### PR DESCRIPTION
## Summary
- update the example Scala specs to use PascalCase identifiers that match the desired canonical naming
- adjust the object reference example to reference the new PascalCase contract ID
- document the PascalCase naming policy in the English and Korean builder guides and refresh code samples accordingly

## Testing
- ./publish.sh

------
https://chatgpt.com/codex/tasks/task_e_68d7aaa937bc8325a5d03bfaa81c592f